### PR TITLE
Fixed wrong use of vault api for perworldpermissions

### DIFF
--- a/src/me/stutiguias/mcmmorankup/updaterank/RankUp.java
+++ b/src/me/stutiguias/mcmmorankup/updaterank/RankUp.java
@@ -257,7 +257,7 @@ public class RankUp extends Util {
         if(plugin.PerWorldPermission) {
             plugin.permission.playerRemoveGroup(player.getWorld(), player.getName(), groupnow);
         }else{
-            plugin.permission.playerRemoveGroup(player, groupnow);
+            plugin.permission.playerRemoveGroup((String)null, player.getName(), groupnow);
         }
     }
     
@@ -265,7 +265,7 @@ public class RankUp extends Util {
         if(plugin.PerWorldPermission) {
             return plugin.permission.playerAddGroup(player.getWorld(), player.getName(), group);
         }
-        return plugin.permission.playerAddGroup(player, group);
+        return plugin.permission.playerAddGroup((String)null, player.getName(), group);
     }
     
     private String BroadcastMessage(String group, String skill, boolean demote) {


### PR DESCRIPTION
Current Behaviour: global group change does not work with permissionsex

Resolution:
A String with value null should be given to vault, when the group has to
be modified globally.
The current method changes only the group in the world the player is in.
Tested with PermissionsEx.

For further information, please read the javadoc of vault:
https://github.com/MilkBowl/Vault/blob/master/src/net/milkbowl/vault/permission/Permission.java#L490
https://github.com/MilkBowl/Vault/blob/master/src/net/milkbowl/vault/permission/Permission.java#L519
